### PR TITLE
adds ike-prow-plugins services

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -4,4 +4,9 @@ contexts:
     services_dir: error-tracking-services
     templates_dir: error-tracking-templates
   name: error-tracking
+- data:
+    output_dir: ike-prow-plugins-processed
+    services_dir: ike-prow-plugins-services
+    templates_dir: ike-prow-plugins-templates
+  name: ike-prow-plugins
 current: error-tracking

--- a/ike-prow-plugins-services/hook.yaml
+++ b/ike-prow-plugins-services/hook.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 2f3ad698ffcff53f881d3292a1b3da894bf1d5f7
+- hash: none
   name: hook
   path: /cluster/hook-template.yaml
   url: https://github.com/arquillian/ike-prow-plugins

--- a/ike-prow-plugins-services/hook.yaml
+++ b/ike-prow-plugins-services/hook.yaml
@@ -1,0 +1,9 @@
+services:
+- hash: 2f3ad698ffcff53f881d3292a1b3da894bf1d5f7
+  name: hook
+  path: /cluster/hook-template.yaml
+  url: https://github.com/arquillian/ike-prow-plugins
+  hash_length: 6
+  parameters:
+    REGISTRY=push.registry.devshift.net
+    DOCKER_REPO=ike-prow-plugins

--- a/ike-prow-plugins-services/hook.yaml
+++ b/ike-prow-plugins-services/hook.yaml
@@ -5,5 +5,5 @@ services:
   url: https://github.com/arquillian/ike-prow-plugins
   hash_length: 6
   parameters:
-    REGISTRY=push.registry.devshift.net
+    REGISTRY=prod.registry.devshift.net/osio-prod
     DOCKER_REPO=ike-prow-plugins

--- a/ike-prow-plugins-services/test-keeper.yaml
+++ b/ike-prow-plugins-services/test-keeper.yaml
@@ -5,6 +5,6 @@ services:
   url: https://github.com/arquillian/ike-prow-plugins
   hash_length: 6
   parameters:
-    REGISTRY=push.registry.devshift.net
+    REGISTRY=prod.registry.devshift.net/osio-prod
     DOCKER_REPO=ike-prow-plugins
     PLUGIN_NAME=test-keeper

--- a/ike-prow-plugins-services/test-keeper.yaml
+++ b/ike-prow-plugins-services/test-keeper.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: e882b7e072d56f70f01dfe658915cd7f64c7cef0
+- hash: 04b5c6ccef95644848d90b7d2700b734d5379692
   name: test-keeper
   path: /cluster/ike-prow-template.yaml
   url: https://github.com/arquillian/ike-prow-plugins

--- a/ike-prow-plugins-services/test-keeper.yaml
+++ b/ike-prow-plugins-services/test-keeper.yaml
@@ -1,0 +1,10 @@
+services:
+- hash: e882b7e072d56f70f01dfe658915cd7f64c7cef0
+  name: test-keeper
+  path: /cluster/ike-prow-template.yaml
+  url: https://github.com/arquillian/ike-prow-plugins
+  hash_length: 6
+  parameters:
+    REGISTRY=push.registry.devshift.net
+    DOCKER_REPO=ike-prow-plugins
+    PLUGIN_NAME=test-keeper

--- a/ike-prow-plugins-services/test-keeper.yaml
+++ b/ike-prow-plugins-services/test-keeper.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 04b5c6ccef95644848d90b7d2700b734d5379692
+- hash: none
   name: test-keeper
   path: /cluster/ike-prow-template.yaml
   url: https://github.com/arquillian/ike-prow-plugins

--- a/ike-prow-plugins-services/work-in-progress.yaml
+++ b/ike-prow-plugins-services/work-in-progress.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: e882b7e072d56f70f01dfe658915cd7f64c7cef0
+- hash: 04b5c6ccef95644848d90b7d2700b734d5379692
   name: work-in-progress
   path: /cluster/ike-prow-template.yaml
   url: https://github.com/arquillian/ike-prow-plugins

--- a/ike-prow-plugins-services/work-in-progress.yaml
+++ b/ike-prow-plugins-services/work-in-progress.yaml
@@ -5,6 +5,6 @@ services:
   url: https://github.com/arquillian/ike-prow-plugins
   hash_length: 6
   parameters:
-    REGISTRY=push.registry.devshift.net
+    REGISTRY=prod.registry.devshift.net/osio-prod
     DOCKER_REPO=ike-prow-plugins
     PLUGIN_NAME=work-in-progress

--- a/ike-prow-plugins-services/work-in-progress.yaml
+++ b/ike-prow-plugins-services/work-in-progress.yaml
@@ -1,0 +1,10 @@
+services:
+- hash: e882b7e072d56f70f01dfe658915cd7f64c7cef0
+  name: work-in-progress
+  path: /cluster/ike-prow-template.yaml
+  url: https://github.com/arquillian/ike-prow-plugins
+  hash_length: 6
+  parameters:
+    REGISTRY=push.registry.devshift.net
+    DOCKER_REPO=ike-prow-plugins
+    PLUGIN_NAME=work-in-progress

--- a/ike-prow-plugins-services/work-in-progress.yaml
+++ b/ike-prow-plugins-services/work-in-progress.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 04b5c6ccef95644848d90b7d2700b734d5379692
+- hash: none
   name: work-in-progress
   path: /cluster/ike-prow-template.yaml
   url: https://github.com/arquillian/ike-prow-plugins


### PR DESCRIPTION
Adds ike-prow-plugins services. The templates are here https://github.com/arquillian/ike-prow-plugins/tree/master/cluster
PR that adds build-master job to the ci.centos.org is here https://github.com/openshiftio/openshiftio-cico-jobs/pull/661