### PR TITLE
chore: add pr-sanitizer service

### DIFF
--- a/ike-prow-plugins-services/pr-sanitizer.yaml
+++ b/ike-prow-plugins-services/pr-sanitizer.yaml
@@ -1,0 +1,10 @@
+services:
+- hash: none
+  name: pr-sanitizer
+  path: /cluster/ike-prow-template.yaml
+  url: https://github.com/arquillian/ike-prow-plugins
+  hash_length: 6
+  parameters:
+    REGISTRY: prod.registry.devshift.net/osio-prod
+    DOCKER_REPO: ike-prow-plugins
+    PLUGIN_NAME: pr-sanitizer


### PR DESCRIPTION
Currently we have `pr-sanitizer` plugin's initial implementation available which needs to run as service where all other `ike-prow-plugin` services are running.

**What is PR-Sanitizer plugin?**
This plugin enforces writing effective pull requests that confirm with proper naming conventions and description. More details can be found at http://arquillian.org/ike-prow-plugins/#_pr_sanitizer_plugin