### PR TITLE
Use images from quay.io/openshiftio

### DIFF
--- a/ike-prow-plugins-services/hook.yaml
+++ b/ike-prow-plugins-services/hook.yaml
@@ -5,5 +5,5 @@ services:
   url: https://github.com/arquillian/ike-prow-plugins
   hash_length: 6
   parameters:
-    REGISTRY: prod.registry.devshift.net/osio-prod
+    REGISTRY: quay.io/openshiftio
     DOCKER_REPO: ike-prow-plugins

--- a/ike-prow-plugins-services/pr-sanitizer.yaml
+++ b/ike-prow-plugins-services/pr-sanitizer.yaml
@@ -5,6 +5,6 @@ services:
   url: https://github.com/arquillian/ike-prow-plugins
   hash_length: 6
   parameters:
-    REGISTRY: prod.registry.devshift.net/osio-prod
+    REGISTRY: quay.io/openshiftio
     DOCKER_REPO: ike-prow-plugins
     PLUGIN_NAME: pr-sanitizer

--- a/ike-prow-plugins-services/test-keeper.yaml
+++ b/ike-prow-plugins-services/test-keeper.yaml
@@ -5,6 +5,6 @@ services:
   url: https://github.com/arquillian/ike-prow-plugins
   hash_length: 6
   parameters:
-    REGISTRY: prod.registry.devshift.net/osio-prod
+    REGISTRY: quay.io/openshiftio
     DOCKER_REPO: ike-prow-plugins
     PLUGIN_NAME: test-keeper

--- a/ike-prow-plugins-services/work-in-progress.yaml
+++ b/ike-prow-plugins-services/work-in-progress.yaml
@@ -5,6 +5,6 @@ services:
   url: https://github.com/arquillian/ike-prow-plugins
   hash_length: 6
   parameters:
-    REGISTRY: prod.registry.devshift.net/osio-prod
+    REGISTRY: quay.io/openshiftio
     DOCKER_REPO: ike-prow-plugins
     PLUGIN_NAME: work-in-progress


### PR DESCRIPTION
registry.devshift.net is being deprecated. This updates the configs to use images from quay.io/openshiftio